### PR TITLE
Implement GitHub Actions Workflow for Releases

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -29,7 +29,10 @@ jobs:
         run: npm run build
 
       - name: Prepare build directory
-        run: mv build ollama-webui-lite
+        run: |
+          mv build ollama-webui-lite
+          cp README.md ollama-webui-lite/README.md
+          cp LICENSE ollama-webui-lite/LICENSE
 
       - name: Zip build artifacts
         run: zip -r ollama-webui-lite.zip ./ollama-webui-lite

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -1,0 +1,65 @@
+name: Build site and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with Vite.js
+        run: npm run build
+
+      - name: Prepare build directory
+        run: mv build ollama-webui-lite
+
+      - name: Zip build artifacts
+        run: zip -r ollama-webui-lite.zip ./ollama-webui-lite
+
+      - name: Tar and Gzip build artifacts
+        run: tar -czvf ollama-webui-lite.tar.gz ./ollama-webui-lite
+        # Creates a .tar.gz file of the build directory
+
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ github.ref_name }}
+          body: |
+            ## Release ${{ github.ref_name }} of Ollama WebUI Lite
+            
+            ### 🚀 New Features
+            - List new features here
+            - Improvements or bug fixes
+      
+            ### 📦 Installation Instructions
+            To deploy Ollama WebUI Lite to your webserver, follow these steps:
+            1. Download the appropriate build archive for your system (`.zip` or `.tar.gz`).
+            2. Unzip or untar the archive in your desired directory.
+            3. Ensure your webserver (e.g., Apache, Nginx) points to the extracted directory.
+            4. Open your web browser and navigate to the URL of your webserver.
+      
+          tag_name: ${{ github.ref_name }}
+          files: |
+            ollama-webui-lite.zip
+            ollama-webui-lite.tar.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true # Adjust these as preferred
+          prerelease: true # Adjust these as preferred


### PR DESCRIPTION
![Screenshot 2024-02-15 at 9 27 38 AM](https://github.com/ollama-webui/ollama-webui-lite/assets/52832301/62fbc04c-90b0-4060-a2c2-ce8c759ae07a)

This PR introduces a new GitHub Actions workflow aimed at automating the process of building and releasing `ollama-webui-lite`.

#### Key Changes:
- Automated build and packaging of the `ollama-webui-lite` project into `.zip` and `.tar.gz` formats.
- Automated creation of a GitHub release with a detailed and formatted release message and installation instructions.
- Direct uploading of build artifacts to the newly created release, making them readily available for download by users.

#### Addresses:
- #6 

#### How to use:
Just tag a commit and push:
```bash
git tag -a v0.0.10 -m "v0.0.10" && git push origin v0.0.10
```
![Screenshot 2024-02-15 at 9 28 27 AM](https://github.com/ollama-webui/ollama-webui-lite/assets/52832301/66019d3b-ae20-4d5d-96dc-fc4950dd68e4)

#### Things you may want to modify first:
- Release message title and body
- the `draft` and `prerelease` settings